### PR TITLE
Choose path to `rsvg-convert` depending on arch.

### DIFF
--- a/AppClipCodeGenerator/Models/AppClipCodeGenerator.swift
+++ b/AppClipCodeGenerator/Models/AppClipCodeGenerator.swift
@@ -132,7 +132,11 @@ class AppClipCodeGenerator {
     }
     
     private func convertToPNG(sourcePath: String, targetPath: String) -> String? {
+        #if arch(x86_64)
         let path = "/usr/local/bin/rsvg-convert"
+        #elseif arch(arm64)
+        let path = "/opt/homebrew/bin/rsvg-convert"
+        #endif
         
         if let data = Process.execute(path, arguments: ["-h", "1024", sourcePath, "-o", targetPath]) {
             let string = String(data: data, encoding: .utf8)


### PR DESCRIPTION
With this PR, the path to `rsvg-convert` will be set according to the architecture, supporting M1 Macs.

Resolves #1